### PR TITLE
Pull requests wolfmayr

### DIFF
--- a/src/components/ProvVis.tsx
+++ b/src/components/ProvVis.tsx
@@ -395,10 +395,8 @@ function ProvVis<T, S extends string, A>({
 
   if (maxWidth === 0) {
     shiftLeft = 30;
-  } else if (maxWidth === 1) {
-    shiftLeft = 52;
-  } else if (maxWidth > 1) {
-    shiftLeft = 74;
+  } else {
+    shiftLeft = 30 + maxWidth * 22;
   }
 
   let svgWidth = width;

--- a/src/components/ProvVis.tsx
+++ b/src/components/ProvVis.tsx
@@ -347,6 +347,8 @@ function ProvVis<T, S extends string, A>({
     }
   }
 
+  maxHeight = maxHeight * verticalSpace + 200;
+
   const links = stratifiedTree.links();
 
   const xOffset = gutter;


### PR DESCRIPTION
For maxHeight you probably just forgot to multiply it with verticalSpace. The +200 are just that the tree isn't completely at the edge.

For shifLeft I am not sure why you only shift left for a maximum of 74, but I think shifting dynamically so the current path is always visible is useful.